### PR TITLE
Stub out code for case sensitive matching

### DIFF
--- a/pages/api/response.ts
+++ b/pages/api/response.ts
@@ -61,7 +61,6 @@ export default async function handler(
     }
 
     const keyword = rawKeyword
-      .toLowerCase()
       .trim()
       .replace(/[‘’“”'"]+/g, "");
 


### PR DESCRIPTION
We store 2 mappings now, one with case-sensitive keywords and one with insensitive keywords. When matching in regex, we perform it insensitively, and lookup both mappings to see which teams we should be notifying.